### PR TITLE
details which should be the  recommended pecl package

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -10,8 +10,13 @@ the 7.x-1.x version of this module!
 - PHP 5.5 or greater
 - Availability of a memcached daemon: http://memcached.org/
 - One of the two PECL memcache packages:
-  - http://pecl.php.net/package/memcache (recommended)
+  - http://pecl.php.net/package/memcache 
   - http://pecl.php.net/package/memcached
+
+### How to choose between these 2 packages ? ###
+http://pecl.php.net/package/memcache is recommended if you have deamon running on the same instance as your php server and that your php major version allows it. 
+http://pecl.php.net/package/memcached is recommended if your daemon is not on the same instance and if your php major version is 7.
+
 
 For more detailed instructions on installing a memcached daemon or either of the
 memcache PECL extensions, please see the documentation online at


### PR DESCRIPTION
Hi,
I've detailled the pecl package part, because on my current project hosted on AWS, I was wondering why memcache was marked as recommended.
After some research, and questions on various drupal's slack channels, I've found that memcache was recommended for performances reason when the memcached daemon runs on the same instance than the PHP server, and also if your PHP version is less than 7.
So I think the README.txt need to be updated to share this information.

Kind regards,
David